### PR TITLE
Lithuanian version font fix

### DIFF
--- a/index_lt.html
+++ b/index_lt.html
@@ -12,17 +12,19 @@
 
   <title>Tarptautinis Atvirų duomenų hakatonas</title>
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
-  <script src="js/cufon.js" type="text/javascript" charset="utf-8"></script>
-  <script src="js/comicsans.js" type="text/javascript" charset="utf-8"></script>
+  <!-- <script src="js/cufon.js" type="text/javascript" charset="utf-8"></script> -->
+  <!-- <script src="js/comicsans.js" type="text/javascript" charset="utf-8"></script> -->
   <script src="js/scrollto.js" type="text/javascript" charset="utf-8"></script>
   <script src="js/scrolllocal.js" type="text/javascript" charset="utf-8"></script>
 
+	<!--
   <script type="text/javascript" >
   Cufon.replace('h1')('h2')('h3')('h4')('h5');
   $(document).ready( function() {
     $.localScroll();
   });
   </script>
+  -->
 </head>
 
 <body>


### PR DESCRIPTION
I disabled Cufon on the index_lt.html so that lithuanian characters are at least shown in standard font.
Please update the page with this version.
