### PR TITLE
Fix event date & links to wiki on non-English pages

### DIFF
--- a/index_fr.html
+++ b/index_fr.html
@@ -104,7 +104,7 @@
           
               <p>Tous ces hackathons à travers le monde seront, comme de petites pièces, liés ensemble par <em>5 principes de base</em>.</p>
 
-              <h4>Ça se déroulera le samedi 23 février.</h4>
+              <h4>Ça se déroulera le samedi 22 février.</h4>
               <p>L'événement peut être petit ou grand, long ou court, c'est vous qui décidez.</p>
               
               <h4>Ce doit être ouvert</h4>
@@ -145,7 +145,7 @@
             
             <div class="col-3 last">
               <h3>Ça se passe où?</h3>
-              <p>Consultez le <a href="http://wiki.opendataday.org/2013/City_Events">wiki</a> pour découvrir le lieu des différents événements - Et s'il n'y en n'a pas, créez-en un!</p>
+              <p>Consultez le <a href="http://wiki.opendataday.org/2014/City_Events">wiki</a> pour découvrir le lieu des différents événements - Et s'il n'y en n'a pas, créez-en un!</p>
               
               <h3>Aidez les organisateurs</h3>
               <p>En plus du <a href="http://wiki.opendataday.org/">wiki</a>, la <a href="http://lists.okfn.org/mailman/listinfo/open-data-day">list de diffusion de l'Open Knowledge Foundation</a> sert de point de rencontre pour l'organisation.</p>
@@ -157,11 +157,11 @@
             <h2>Commencez dès maintenant!</h2>
             <div class="col-3">
               <h3>Les idées d'application</h3>
-              <p>sont toujours les bienvenues. N'hésitez pas à ajouter la votre sur le <a href="http://wiki.opendataday.org/2013/App_Ideas">wiki</a>.</p>
+              <p>sont toujours les bienvenues. N'hésitez pas à ajouter la votre sur le <a href="http://wiki.opendataday.org/2014/App_Ideas">wiki</a>.</p>
             </div><!-- .col-3 -->
             <div class="col-3">
               <h3>Jeux de données</h3>
-              <p>Si vous pensez avoir des jeux de données pertinents pour l'événement en vue de faire des applications ou des visualisations, vous pouvez également les ajouter sur... le <a href="http://wiki.opendataday.org/2013/Data">wiki</a>.</p>
+              <p>Si vous pensez avoir des jeux de données pertinents pour l'événement en vue de faire des applications ou des visualisations, vous pouvez également les ajouter sur... le <a href="http://wiki.opendataday.org/2014/Data">wiki</a>.</p>
             </div><!-- .col-3 -->
             <div class="col-3 last">
               <h3>Le Wiki</h3>
@@ -174,7 +174,7 @@
           <div id="talk" class="block talk clearfix">
             <div class="col-3">
               <h2>Contactez-nous</h2>
-              <p>On vous attend avec enthousiasme le 23 février mais en attendant vous pouvez nous contacter</p>
+              <p>On vous attend avec enthousiasme le 22 février mais en attendant vous pouvez nous contacter</p>
               <ul>
                 <li><a href="mailto:open-data-day@lists.okfn.org">par courriel</a></li>
             
@@ -188,7 +188,7 @@
             
             <div class="col-3 last">
               <h2>Organisateurs</h2>
-              <p><strong>Consultez <a href="http://wiki.opendataday.org/2013/City_Events">le wiki</a> pour trouver les initiateurs d'événements près de chez vous... ou pour le devenir.</strong></p>
+              <p><strong>Consultez <a href="http://wiki.opendataday.org/2014/City_Events">le wiki</a> pour trouver les initiateurs d'événements près de chez vous... ou pour le devenir.</strong></p>
               <p>Cet évébement a été instigué par les personnes suivantes:</p>
               <ul>  
                 <li><strong>Mary Beth Baker</strong>

--- a/index_it.html
+++ b/index_it.html
@@ -105,7 +105,7 @@
           
               <p>Questi hackathons, come piccoli pezzi, saranno uniti liberamente da <em>5 principi base</em>.</p>
 
-              <h4>Saranno tenuti Sabato, 23 febbraio</h4>
+              <h4>Saranno tenuti Sabato, 22 febbraio</h4>
               <p>Può essere grande o piccolo, lungo o breve, come piace a te.</p>
               
               <h4>Deve essere aperto a tutti</h4>
@@ -147,7 +147,7 @@
             
             <div class="col-3 last">
               <h3>Dov'è?</h3>
-              <p>Guarda <a href="http://wiki.opendataday.org/2013/City_Events">il wiki</a> per vedere dove un hackathon sull'open data sarà tenuto vicino a voi - se non c'è uno, organizzatelo!</p>
+              <p>Guarda <a href="http://wiki.opendataday.org/2014/City_Events">il wiki</a> per vedere dove un hackathon sull'open data sarà tenuto vicino a voi - se non c'è uno, organizzatelo!</p>
               
               <h3>Aituo per gli organizzatori</h3>
               <p>In aggiunta al <a href="http://wiki.opendataday.org/">wiki</a> dove le persone si stanno organizzando, c'è anche la <a href="http://lists.okfn.org/mailman/listinfo/open-data-day">mailing list sull'Open Knowledge Foundation</a> che è stata un punto di organizzazione.</p>
@@ -159,11 +159,11 @@
             <h2>Inzia Subito</h2>
             <div class="col-3">
               <h3>Idee per le App</h3>
-              <p>sono sempre benvenute. Aggiungi la tua al <a href="http://wiki.opendataday.org/2013/App_Ideas">wiki.</a></p>
+              <p>sono sempre benvenute. Aggiungi la tua al <a href="http://wiki.opendataday.org/2014/App_Ideas">wiki.</a></p>
             </div><!-- .col-3 -->
             <div class="col-3">
               <h3>Gruppi di Dati</h3>
-              <p>Se pensi di aver trovato un set di dati che è interessante e che potrebbe essere utile per una app o per la visualizzazione, aggiungilo al <a href="http://wiki.opendataday.org/2013/Data"> wiki</a>.</p>
+              <p>Se pensi di aver trovato un set di dati che è interessante e che potrebbe essere utile per una app o per la visualizzazione, aggiungilo al <a href="http://wiki.opendataday.org/2014/Data"> wiki</a>.</p>
             </div><!-- .col-3 -->
             <div class="col-3 last">
               <h3>Il Wiki</h3>
@@ -190,7 +190,7 @@
             
             <div class="col-3 last">
               <h2>Organizzatori</h2>
-              <p><strong>Guardate <a href="http://wiki.opendataday.org/2013/City_Events">il wiki</a> per i promotori in una città vicino a voi (o diventatene uno).</strong></p>
+              <p><strong>Guardate <a href="http://wiki.opendataday.org/2014/City_Events">il wiki</a> per i promotori in una città vicino a voi (o diventatene uno).</strong></p>
               <p>Questa idea è partita come un brainstorming internazionale che ha coinvolto alcuni di questi personaggi:</p>
               <ul>  
                 <li><strong>Mary Beth Baker</strong>

--- a/index_lt.html
+++ b/index_lt.html
@@ -107,7 +107,7 @@
           
               <p>Šiuos hakatonus (eng. hackathon),kaip mažus atskirus elementus, jungia <em>5 dalykai</em>:</p>
 
-              <h4>Veiksmas vyksta vasario 23 dieną, šeštadienį</h4>
+              <h4>Veiksmas vyksta vasario 22 dieną, šeštadienį</h4>
               <p>Hakatonas gali būti mažas ar didėlis, ilgas ar trumpas, toks, kokio norite jūs.</p>
               
               <h4>Hakatonas turi būti atviras</h4>
@@ -147,7 +147,7 @@
             
             <div class="col-3 last">
               <h3>Kur?</h3>
-              <p>Užeik į mūsų <a href="http://wiki.opendataday.org/2013/City_Events">wiki puslapį</a> ir patikrink, ar hakatonas vyksta tavo mieste. Jeigu ne – suorganizuok jį pats!</p>
+              <p>Užeik į mūsų <a href="http://wiki.opendataday.org/2014/City_Events">wiki puslapį</a> ir patikrink, ar hakatonas vyksta tavo mieste. Jeigu ne – suorganizuok jį pats!</p>
               
               <h3>Padėk organizatoriams</h3>
               <p>Be <a href="http://wiki.opendataday.org/">wiki puslapio</a>, kuriame viskas organizuojama, taip pat yra <a href="http://lists.okfn.org/mailman/listinfo/open-data-day">„Open Knowledge Foundation“ el. pašto grupė</a>, kuri gali tapti pradžios tašku.</p>
@@ -159,11 +159,11 @@
             <h2>Pradėk dabar</h2>
             <div class="col-3">
               <h3>Programėlių idėjos</h3>
-              <p>visada laukiamos. Pridėk savo idėją <a href="http://wiki.opendataday.org/2013/App_Ideas">wiki puslapyje</a>.</p>
+              <p>visada laukiamos. Pridėk savo idėją <a href="http://wiki.opendataday.org/2014/App_Ideas">wiki puslapyje</a>.</p>
             </div><!-- .col-3 -->
             <div class="col-3">
               <h3>Duomenų rinkiniai</h3>
-              <p>Jeigu manai, kad radai duomenis, kurie būtų naudingi programėlei ar kitai vizualizacijai, pridėk juos <a href="http://wiki.opendataday.org/2013/Data">wiki puslapyje</a>.</p>
+              <p>Jeigu manai, kad radai duomenis, kurie būtų naudingi programėlei ar kitai vizualizacijai, pridėk juos <a href="http://wiki.opendataday.org/2014/Data">wiki puslapyje</a>.</p>
             </div><!-- .col-3 -->
             <div class="col-3 last">
               <h3>Wiki puslapis</h3>
@@ -190,7 +190,7 @@
             
             <div class="col-3 last">
               <h2>Organizatoriai</h2>
-              <p><strong>Užeik į <a href="http://wiki.opendataday.org/2013/City_Events">wiki puslapį</a> norėdamas surasti savo miesto organizatorius (arba tapti vienu iš jų).</strong></p>
+              <p><strong>Užeik į <a href="http://wiki.opendataday.org/2014/City_Events">wiki puslapį</a> norėdamas surasti savo miesto organizatorius (arba tapti vienu iš jų).</strong></p>
               <p>Procesą šiek tiek koordinuoja David Eaves ir Rufus Pollock.</p>
 
               </ul>

--- a/index_pl.html
+++ b/index_pl.html
@@ -103,7 +103,7 @@
           
               <p>Wszystkie hackatony pod szyldem Open Data Day spaja <em>5 głównych zasad</em>.</p>
 
-              <h4>Będą odbywać się w sobotę, 23 lutego</h4>
+              <h4>Będą odbywać się w sobotę, 22 lutego</h4>
               <p>Mogą być duże lub małe, krótsze lub dłuższe, wedle potrzeby. Odbywają się tego samego dnia, co <a href="http://www.rhok.org/2010/10/registration-for-rhok-2-is-open/">Random Hacks of Kindnesses Codesprint</a> - sprawdzie co się dzieje u nich, bo oni też robią niesamowite rzeczy.</p>
               
               <h4>Powinny być otwarte</h4>
@@ -145,7 +145,7 @@
             
             <div class="col-3 last">
               <h3>Gdzie to się dzieje?</h3>
-              <p>Sprawdź <a href="http://wiki.opendataday.org/2013/City_Events">wiki</a>, aby dowiedzieć się, gdzie organizowany jest najbliższy open data hackaton - jeśli nie ma takiego, zorganizuj go!</p>
+              <p>Sprawdź <a href="http://wiki.opendataday.org/2014/City_Events">wiki</a>, aby dowiedzieć się, gdzie organizowany jest najbliższy open data hackaton - jeśli nie ma takiego, zorganizuj go!</p>
               
               <h3>Pomoc dla organizatorów</h3>
               <p>Poza <a href="http://wiki.opendataday.org/">wiki</a>, gdzie ludzie się organizują, jest również <a href="http://lists.okfn.org/mailman/listinfo/open-data-day">lista mailingowa Open Knowledge Foundation</a> która jest naszym punktem zbornym.</p>
@@ -157,11 +157,11 @@
             <h2>Włącz się w Open Data Hackaton już teraz</h2>
             <div class="col-3">
               <h3>Pomysły na aplikacje</h3>
-              <p>zawsze mile widziane. dodaj swoje do <a href="http://wiki.opendataday.org/2013/App_Ideas">wiki tutaj.</a></p>
+              <p>zawsze mile widziane. dodaj swoje do <a href="http://wiki.opendataday.org/2014/App_Ideas">wiki tutaj.</a></p>
             </div><!-- .col-3 -->
             <div class="col-3">
               <h3>Zbiory danych</h3>
-              <p>Jeśli sądzisz, że znalazłeś interesujące dane, które mogłyby być podstawą aplikacji lub wizualizacji, dodaj je do <a href="http://wiki.opendataday.org/2013/Data">wiki</a>.</p>
+              <p>Jeśli sądzisz, że znalazłeś interesujące dane, które mogłyby być podstawą aplikacji lub wizualizacji, dodaj je do <a href="http://wiki.opendataday.org/2014/Data">wiki</a>.</p>
             </div><!-- .col-3 -->
             <div class="col-3 last">
               <h3>Wiki</h3>
@@ -188,7 +188,7 @@
             
             <div class="col-3 last">
               <h2>Organizatorzy</h2>
-              <p><strong>Sprawdź <a href="http://wiki.opendataday.org/2013/City_Events">wiki</a> kto jest inicjatorem w Twoim mieście (lub też Ty nim zostań).</strong></p>
+              <p><strong>Sprawdź <a href="http://wiki.opendataday.org/2014/City_Events">wiki</a> kto jest inicjatorem w Twoim mieście (lub też Ty nim zostań).</strong></p>
               <p>To przedsięwzięcia wystartowało jako rezultat międzynarodowej burzy mozgów, w której brali udział m.in.:</p>
               <ul>  
                 <li><strong>Mary Beth Baker</strong>

--- a/index_pt.html
+++ b/index_pt.html
@@ -104,7 +104,7 @@
            
               <p>Estas hackathons, como pequenas peças, vão partilhar entre si um conjunto de <em>5 princípios base</em>.</p>
  
-              <h4>Vai acontecer no sábado, 23 de fevereiro</h4>
+              <h4>Vai acontecer no sábado, 22 de fevereiro</h4>
               <p>Pode ser tão grande ou tão pequeno como quiseres.</p>
                
               <h4>Deve ser aberto</h4>
@@ -144,7 +144,7 @@
              
             <div class="col-3 last">
               <h3>Onde é?</h3>
-              <p>Vê <a href="http://wiki.opendataday.org/2013/City_Events">a wiki</a> para encontrar a hackathon de dados abertos mais próxima de ti - se não houver organiza tu uma!</p>
+              <p>Vê <a href="http://wiki.opendataday.org/2014/City_Events">a wiki</a> para encontrar a hackathon de dados abertos mais próxima de ti - se não houver organiza tu uma!</p>
                
               <h3>Ajuda para os Organizadores</h3>
               <p>Além <a href="http://wiki.opendataday.org/">da wiki</a> onde as pessoas se estão a organizar também há <a href="http://lists.okfn.org/mailman/listinfo/open-data-day">a mailing list da Open Knowledge Foundation</a> que tem sido o ponto central de coordenação.</p>
@@ -156,11 +156,11 @@
             <h2>Mete as mãos na massa e começa o Hackfest agora</h2>
             <div class="col-3">
               <h3>Ideias para Apps</h3>
-              <p>são sempre bem vindas. Adiciona a tua <a href="http://wiki.opendataday.org/2013/App_Ideas">nesta página da wiki.</a></p>
+              <p>são sempre bem vindas. Adiciona a tua <a href="http://wiki.opendataday.org/2014/App_Ideas">nesta página da wiki.</a></p>
             </div><!-- .col-3 -->
             <div class="col-3">
               <h3>Datasets</h3>
-              <p>Se achas que encontraste um conjunto de dados que é interessante e pode ser usado numa app ou numa visualização, adiciona-o <a href="http://wiki.opendataday.org/2013/Data">na wiki</a>.</p>
+              <p>Se achas que encontraste um conjunto de dados que é interessante e pode ser usado numa app ou numa visualização, adiciona-o <a href="http://wiki.opendataday.org/2014/Data">na wiki</a>.</p>
             </div><!-- .col-3 -->
             <div class="col-3 last">
               <h3>A Wiki</h3>
@@ -187,7 +187,7 @@
              
             <div class="col-3 last">
               <h2>Organizadores</h2>
-              <p><strong>Vê <a href="http://wiki.opendataday.org/2013/City_Events">a wiki</a> para encontrar os agitadores mais perto de ti (ou torna-te um deles).</strong></p>
+              <p><strong>Vê <a href="http://wiki.opendataday.org/2014/City_Events">a wiki</a> para encontrar os agitadores mais perto de ti (ou torna-te um deles).</strong></p>
               <p>Esta ideia começou num brainstorm internacional que envolveu alguns dos seguintes nomes:</p>
               <ul>   
                 <li><strong>Mary Beth Baker</strong>

--- a/index_zh.html
+++ b/index_zh.html
@@ -149,7 +149,7 @@
             
             <div class="col-3 last">
               <h3>地點在哪裡？</h3>
-              <p>請查查 <a href="http://wiki.opendataday.org/2013/City_Events">wiki 頁面</a> 找出離你最近舉辦活動的城市。如果沒有，那自己辦一場吧！</p>
+              <p>請查查 <a href="http://wiki.opendataday.org/2014/City_Events">wiki 頁面</a> 找出離你最近舉辦活動的城市。如果沒有，那自己辦一場吧！</p>
               
               <h3>如果您想舉辦活動</h3>
               <p>如了在 <a href="http://wiki.opendataday.org/">wiki 頁面</a>可以找到其他主辦單位之外，你也可以透過 <a href="http://lists.okfn.org/mailman/listinfo/open-data-day">the Open Knowledge Foundation 的郵件論壇</a>尋求協助。</p>
@@ -161,11 +161,11 @@
             <h2>馬上開始</h2>
             <div class="col-3">
               <h3>App 點子</h3>
-              <p>總是在需求優先清單，把你的點子放在 <a href="http://wiki.opendataday.org/2013/App_Ideas">wiki 頁面吧。</a></p>
+              <p>總是在需求優先清單，把你的點子放在 <a href="http://wiki.opendataday.org/2014/App_Ideas">wiki 頁面吧。</a></p>
             </div><!-- .col-3 -->
             <div class="col-3">
               <h3>資料集</h3>
-              <p>如果你覺得你找到很棒的資料集，對於進行視覺化的分析會很有幫助， 那麼加入這個 <a href="http://wiki.opendataday.org/2013/Data">wiki 頁面</a>。</p>
+              <p>如果你覺得你找到很棒的資料集，對於進行視覺化的分析會很有幫助， 那麼加入這個 <a href="http://wiki.opendataday.org/2014/Data">wiki 頁面</a>。</p>
             </div><!-- .col-3 -->
             <div class="col-3 last">
               <h3>Wiki 頁面</h3>
@@ -192,7 +192,7 @@
             
             <div class="col-3 last">
               <h2>活動主辦單位</h2>
-              <p><strong>請看 <a href="http://wiki.opendataday.org/2013/City_Events">wiki 頁面</a>找尋各個城市的舉辦狀況，或是自己辦理一場。</strong></p>
+              <p><strong>請看 <a href="http://wiki.opendataday.org/2014/City_Events">wiki 頁面</a>找尋各個城市的舉辦狀況，或是自己辦理一場。</strong></p>
               <p>本活動是在一次的腦力激盪中所開始的，我們要感謝原來發起這個活動的人們：</p>
               <ul>  
                 <li><strong>Mary Beth Baker</strong>


### PR DESCRIPTION
The links to the wiki where still pointing to the pages of the 2013 edition
Throughout the page (except for the main title), the event date was still set to Feb 23.
