### PR TITLE
Add # of events registered to map overlay

### DIFF
--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -44,6 +44,8 @@ map.on('load', function() {
       }
     });
 
+    $("#event-number").text(data.feed.entry.length);
+
     map.addSource("events", {
       "type": "geojson",
       "data": geojson,

--- a/templates/home.html
+++ b/templates/home.html
@@ -118,7 +118,7 @@
     <div>
       <div>
         <a href="https://docs.google.com/spreadsheets/d/1cV43fuzwy2q2ZKDWrHVS6XR4O8B01eLevh4PD6nCENE/edit#gid=98436325" rel="external">{{ this.register_text }}</a>
-        <span class="count">x {{ this.events_registered }}</span>
+        <span class="count"><span id="event-number">0</span> {{ this.events_registered }}</span>
       </div>
     </div>
   </header>


### PR DESCRIPTION
The number of events registered will differ from amount shown on map
because not all registered events have sufficient info to display (e.g.
lng,lat). Fixes #131  