### PR TITLE
fix click to zoom by updating the mapbox workarounds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
         separator: '\n',
       },
       dist: {
-        src: ['node_modules/waypoints/lib/jquery.waypoints.min.js', 'node_modules/waypoints/lib/shortcuts/sticky.min.js', 'node_modules/jquery-smooth-scroll/jquery.smooth-scroll.min.js', 'node_modules/slicknav/dist/jquery.slicknav.min.js']
+        src: ['node_modules/waypoints/lib/jquery.waypoints.min.js', 'node_modules/waypoints/lib/shortcuts/sticky.min.js', 'node_modules/jquery-smooth-scroll/jquery.smooth-scroll.min.js', 'node_modules/slicknav/dist/jquery.slicknav.min.js'],
         dest: 'assets/js/plugins.js',
       },
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
         separator: '\n',
       },
       dist: {
-        src: ['node_modules/waypoints/lib/jquery.waypoints.min.js', 'node_modules/waypoints/lib/shortcuts/sticky.min.js', 'node_modules/jquery-smooth-scroll/jquery.smooth-scroll.min.js', 'node_modules/slicknav/dist/jquery.slicknav.min.js', 'node_modules/supercluster/dist/supercluster.min.js'],
+        src: ['node_modules/waypoints/lib/jquery.waypoints.min.js', 'node_modules/waypoints/lib/shortcuts/sticky.min.js', 'node_modules/jquery-smooth-scroll/jquery.smooth-scroll.min.js', 'node_modules/slicknav/dist/jquery.slicknav.min.js']
         dest: 'assets/js/plugins.js',
       },
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "jquery-smooth-scroll": "^2.1.2",
     "normalize.css": "^5.0.0",
     "slicknav": "^1.0.8",
-    "supercluster": "^2.3.0",
     "waypoints": "^4.0.1"
   },
   "author": "Sam Smith",


### PR DESCRIPTION
The direct use of the `supercluster` library code was not in sync after update of `mapbox-gl-js` and its internal version of `supercluster`. Luckily, the direct use of `supercluster` is not necessary any more and could be removed.

Most of the code in the diff (from `map.getCenter()` to the end of the function) changes just in the amount of indentation. 