### PR TITLE
fix incompatibility with python3

### DIFF
--- a/templates/includes/nav.html
+++ b/templates/includes/nav.html
@@ -4,7 +4,7 @@
       <a class="logo" href="{{ '/'|url }}">{% include 'includes/logo.svg' %}</a>
 
       <ul class="menu" id="nav">
-        {% for label, path in bag('main-nav', this.alt).iteritems() %}
+        {% for label, path in bag('main-nav', this.alt).items() %}
         <li{% if this.is_child_of(path) %} class="active"{% endif
           %}><a href="{{ path }}">{{ label }}</a>
       {% endfor %}


### PR DESCRIPTION
You can end up having Lektor run under Python version 2 or Python version 3. Running under Python 3 works if this incompatibility is fixed. (There is no `iteritems` in Python 3).