### PR TITLE
fix model name

### DIFF
--- a/content/contents+fr.lr
+++ b/content/contents+fr.lr
@@ -1,4 +1,4 @@
-_model: Accueil
+_model: home
 ---
 next_date: 2020-03-07
 ---


### PR DESCRIPTION
At the top of the page, the `_model` name needs to be `home` in English. This translation had also translated `home`, which broke the build for this page.
