### PR TITLE
The year on the Japanese page is wrong.

### DIFF
--- a/databags/global-content.ini
+++ b/databags/global-content.ini
@@ -60,7 +60,7 @@ icon_licence = This site uses icons from [icomoon](https://icomoon.io) under the
 
 [ja]
 open_data_day = オープンデータ・デイ
-banner_content_1 = オープンデータ・デイ2020が開催されます
+banner_content_1 = オープンデータ・デイ2021が開催されます
 banner_content_2 = 2021/3/6(土)
 menu_label = Menu
 footer = This is a bottom-up initiative.  Like in previous years, the Open Knowledge Foundation helps maintain this website and works with mini-grant supporters to foster a community. Everyone can contribute. You can contact the [mailing list](https://groups.google.com/forum/#!forum/open-data-day)or go to the [GitHub repo](https://github.com/okfn/opendataday) | [Privacy Policy](https://okfn.org/privacy-policy/)


### PR DESCRIPTION
# Overview
The year was wrong on the Japanese page.
Changed from 2020 to 2021

---

Please preserve this line to notify @StephenAbbott
