### PR TITLE
Make mini-grants title in homepage translatable

### DIFF
--- a/content/contents+pt_br.lr
+++ b/content/contents+pt_br.lr
@@ -12,7 +12,8 @@ title: Você está convidada(o)
 banner_heading_1: Você está convidada(o).
 ---
 banner_heading_2: De novo!
-
+---
+mini_grants_title: Dia dos dados abertos<br/>Mini-grants
 ---
 intro_heading: O que é o Dia dos Dados Abertos?
 ---

--- a/models/home.ini
+++ b/models/home.ini
@@ -38,6 +38,10 @@ type = date
 label = Intro heading
 type = string
 
+[fields.mini_grants_title]
+label = Mini-grants home title
+type = markdown
+
 [fields.intro_body]
 label = Intro body
 type = markdown

--- a/templates/home.html
+++ b/templates/home.html
@@ -21,7 +21,12 @@
     </div>
     <div class="this-year">
       <header>
-        <h2>Open Data Day<br /> mini-grants</h2>
+	      <h2>{% if this.mini_grants_title %}
+		      {{ this.mini_grants_title }}
+		  {% else %}
+		      Open Data Day<br /> mini-grants
+		  {% endif %}
+	      </h2>
         {{ this.year_intro }}
       </header>
       <ul>


### PR DESCRIPTION
Make it possible to translate Mini-grants title with template variable mini_grants_title. See example at the content/contents+pt_br.lr. 

If there is no translation, uses the english text.

Please preserve this line to notify @StephenAbbott
