### PR TITLE
Match build-deploy dependencies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,3 @@
 # Overview
 
 Please replace this line with full information about your pull request. Thanks!
-
----
-
-Please preserve this line to notify @StephenAbbott

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -13,15 +13,15 @@ jobs:
         with:
           ref: "master"
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
-      - name: Set up Node.js 12
+      - name: Set up Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: Install python dependencies
         run: |


### PR DESCRIPTION
This PR matches the python and node versions of the data script with the ones in the main `build-and-deploy` action.

This will fix errors in actions due to deprecated Python 3.8 actions.
