### PR TITLE
Change event date for Timisoara, Romania

### DIFF
--- a/databags/events-2025.json
+++ b/databags/events-2025.json
@@ -20,8 +20,8 @@
       "world_region_text": ""
     },
     {
-      "event_date": "2025-03-01",
-      "event_name": "[TM] Open Data Day 2025",
+      "event_date": "2025-03-15",
+      "event_name": "Open Data Day 2025",
       "event_photo_url": "",
       "event_purpose": "",
       "event_report_url": "",


### PR DESCRIPTION
# Overview

Pushed the event date to Mar 15, as 1-7 is a very busy period in Romania.