### PR TITLE
Show date as is. Date() mess around with timezones in the browser.

### DIFF
--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -83,7 +83,7 @@ function getLink(url) {
 function getDescription(event) {
   var htmlStr = '<strong>Event:</strong> ' + event.event_name;
 
-  var date = event.event_date ? new Date(event.event_date).toDateString() : '';
+  var date = event.event_date;
   if (date) {
     htmlStr += '<br><strong>Date:</strong> ' + date;
   }


### PR DESCRIPTION
# Overview

Fixes #417 

The date of the event comes in a properly formated `YYYY-MM-DD` string. Since we do not need to do any calculation with it let's just show it as is without creating a Date() object to avoid Javascript being Javascript.
